### PR TITLE
Cleaner config load

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ attributes:
 ```
 python key_distribut0r.py
 ```
+
+## Dry run
+To verify your configuration, you can run `python key_distribut0r.py --dry-run`
+to see what would be changed whithout actually applying those changes.


### PR DESCRIPTION
- Add option `--keys`/`-k` to specify custom keys file path
- Add option `--server`/`-s` to specify custom server file path
- Refactor duplicate code into function
- Allow usage of json config files
- Allow usage of yaml file extension '.yaml' (in addition to '.yml')
- Reorder imports

requires #10 