### PR TITLE
SSH Connection exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ attributes:
 ## Usage
 Run `SSHKeyDistribut0r` to distribute your SSH keys :)
 
+Note, that a pre-installed public key on the server side with a corresponding
+private key (without a passphrase or pre-loaded into a local key agent) is
+required for SSHKeyDistribut0r to work.
+
 ### Options
 * `--dry-run`/`-n`: To verify your configuration whithout actually applying those changes.
 * `--keys`/`-k`: Custom path to keys file

--- a/SSHKeyDistribut0r/key_distribut0r.py
+++ b/SSHKeyDistribut0r/key_distribut0r.py
@@ -104,9 +104,12 @@ def main(args):
                     key_stream.close()
                     server_info_log(server['ip'], server['comment'], ', '.join(server_users))
 
-                except paramiko.ssh_exception.PasswordRequiredException:
+                except paramiko.ssh_exception.AuthenticationException:
                     server_error_log(server['ip'], server['comment'],
                                      'Cannot connect to server because of an authentication problem.')
+                except paramiko.ssh_exception.PasswordRequiredException:
+                    server_error_log(server['ip'], server['comment'],
+                                     'The private key file is protected by a passphrase, which is currently not supported.')
                 except scp.SCPException:
                     server_error_log(server['ip'], server['comment'], 'Cannot send file to server.')
                 except (paramiko.ssh_exception.NoValidConnectionsError, paramiko.ssh_exception.SSHException):


### PR DESCRIPTION
The following PR addresses some misleading exception handling messages according to the description of [`paramiko.ssh_exception.PasswordRequiredException`](http://docs.paramiko.org/en/2.4/api/ssh_exception.html#paramiko.ssh_exception.PasswordRequiredException) and [`paramiko.ssh_exception.AuthenticationException`](http://docs.paramiko.org/en/2.4/api/ssh_exception.html#paramiko.ssh_exception.AuthenticationException).

It also adds a short note to the README, which should help new users while deploying SSHKeyDistribut0r.